### PR TITLE
Start the server with security in mind

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,6 @@ In the future I will improve this example adding database and authentication sup
 ## Usage
 
 ```
-deno run --allow-net server.ts
+deno run --allow-net=:5000 server.ts
 ```
 


### PR DESCRIPTION
If you use `--allow-net`, the server gets full access to all URLs. This PR updates the `README.md` file to start the server in a secure manner, only allowing network traffic on port 5000.

```bash
deno run --allow-net=:5000 server.ts
```

Also see https://deno.land/manual/getting_started/permissions.